### PR TITLE
Added compatibility for OSX (and BSD in general).

### DIFF
--- a/xp
+++ b/xp
@@ -33,14 +33,22 @@ echo "              h : Print this help message."
 exit
 fi;
 
-TODAY=$(date +%s)
+gnudate() {
+    if hash gdate 2>/dev/null; then
+        gdate "$@"
+    else
+        date "$@"
+    fi
+}
+
+TODAY=$(gnudate +%s)
 WEEK=604800
 DAY=$((604800 / 7))
 for i in $(eval echo "{$DAYS..0}")
 do
 DAYX=$(($TODAY - $DAY * $i))
-DAYTITLE=$(date -d "@"$DAYX +%Y-%m-%d\ )
-DAYWORD=$(date -d $DAYTITLE +%A)
+DAYTITLE=$(gnudate -d "@"$DAYX +%Y-%m-%d\ )
+DAYWORD=$(gnudate -d $DAYTITLE +%A)
 DAYCONTENT=$(grep $DAYTITLE $DONE_FILE)
 
 if [[ -z "$DAYCONTENT" && "$OPTION" != -o  ]]


### PR DESCRIPTION
BSD/OS X follows the unix spec for date, which is not compatible with the linux spec. 
Installing coreutils on OS X makes gnu date available as 'gdate'.
